### PR TITLE
Add integration with rolltables for store the images

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -42,6 +42,6 @@
     "token-variants.portraitArtFilterHint": "Portrait art will be limited to files that include/exclude these pieces of text or match the provided regular expression.",
     "token-variants.generalArtFilterHint": "These filters will be used when the search is being performed irrespective of the art type (token/portrait).",
     "token-variants.ProfileListenerError": "Token-Variant-Art: Unable to find profile image to assign right-click listener.",
-    "token-variant.PathNotFoundError": "Unable to find path: ",
-    "token-variant.notifications.warn.invalidTable": "The table \"{tableId}\" could not be found"
+    "token-variants.PathNotFoundError": "Unable to find path: ",
+    "token-variants.notifications.warn.invalidTable": "The table \"{tableId}\" could not be found"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -42,5 +42,6 @@
     "token-variants.portraitArtFilterHint": "Portrait art will be limited to files that include/exclude these pieces of text or match the provided regular expression.",
     "token-variants.generalArtFilterHint": "These filters will be used when the search is being performed irrespective of the art type (token/portrait).",
     "token-variants.ProfileListenerError": "Token-Variant-Art: Unable to find profile image to assign right-click listener.",
-    "token-variant.PathNotFoundError": "Unable to find path: "
+    "token-variant.PathNotFoundError": "Unable to find path: ",
+    "token-variant.notifications.warn.invalidTable": "The table \"{tableId}\" could not be found"
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -33,7 +33,7 @@ export async function parseSearchPaths(debug = false) {
     if (debug) console.log("STARTING: Search Path Parse");
 
     const regexpBucket = /s3:(.*):(.*)/;
-    const regexpRollTable = /rolltable:(.*):(.*)/;
+    const regexpRollTable = /rolltable:(.*)/;
     const regexpForge = /(.*assets\.forge\-vtt\.com\/)(\w+)\/(.*)/;
     let searchPathList = game.settings.get("token-variants", "searchPaths").flat();
     let searchPaths = new Map();
@@ -74,10 +74,10 @@ export async function parseSearchPaths(debug = false) {
             }
         }else if (path.startsWith("rolltable:")) {
             const match = path.match(regexpRollTable);
-            if (match[1]) {
-                let tableId = match[1];
+            if (match[0]) {
+                let tableId = match[0].split(":")[1];
                 let tables = searchPaths.get("rolltable");
-                const table = game.tables.get(tableId);
+                const table = game.tables.contents.find((t) => t.name === tableId);
                 if (!table){
                   ui.notifications.warn(game.i18n.format("token-variants.notifications.warn.invalidTable", { tableId }));
                 } else {
@@ -86,11 +86,12 @@ export async function parseSearchPaths(debug = false) {
                   //	displayChat: "Here the roll text"
                   //});
                   // const result = roll.results[0];
-                  for (let baseTableData of table.data) {
+                  const dataTable = table.data;
+                  for (let baseTableData of dataTable.results) {
                     const path = baseTableData.data.img;
                     const name = baseTableData.data.text;
                     if (tables.has(name)) {
-                      // DO NOTHING CAN't HAPPENED
+                      // DO NOTHING CAN'T BE HAPPENING
                     } else {
                       tables.set(name, path);
                     }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -38,7 +38,7 @@ export async function parseSearchPaths(debug = false) {
     let searchPaths = new Map();
     searchPaths.set("data", []);
     searchPaths.set("s3", new Map());
-
+    searchPaths.set("rolltable", new Map());
     let allForgePaths = [];
     async function walkForgePaths(path, currDir) {
         let files;
@@ -96,6 +96,29 @@ export async function parseSearchPaths(debug = false) {
             forgePathsSetting.push(path);
         }
     }
+
+    let tableId = (game.settings.get("token-variants", "rollTable")).flat();
+    const table = game.tables.get(tableId);
+		if (!table){
+      //ui.notifications.warn(game.i18n.format("token-variants.notifications.warn.invalidTable", { tableId }));
+    } else {
+      // TODO ADD A RANDOMIZER ?
+      //const roll = await table.draw({
+      //	displayChat: "Here the roll text"
+      //});
+      // const result = roll.results[0];
+      for (let baseTableData of table.data) {
+        const path = baseTableData.data.img;
+        const name = baseTableData.data.text;
+        if (searchPaths.get("rolltable").has(name)) {
+          searchPaths.get("rolltable").get(name).push(path);
+        } else {
+          searchPaths.get("rolltable").set(name, path);
+        }
+      }
+    }
+
+
     searchPaths.set("forge", forgePathsSetting);
     if (game.user.can("SETTINGS_MODIFY"))
         game.settings.set("token-variants", "forgevttPaths", forgePathsSetting);

--- a/token-variants.mjs
+++ b/token-variants.mjs
@@ -294,9 +294,7 @@ function registerHUD() {
         const tokenActor = game.actors.get(token.actorId);
         if (tokenActor) {
             actorVariants = tokenActor.getFlag('token-variants', 'variants') || new Map();
-            //actorVariants = actorVariants.filter(path => Boolean(path));
             if (!searchText){
-                //images = [...new Set(images.concat(actorVariants))]
                 actorVariants.forEach((path, key) => {
                     if(path){
                         images.set(key,path)
@@ -318,9 +316,7 @@ function registerHUD() {
         images.forEach((path, key) => {
             const img = isImage(path);
             const vid = isVideo(path);
-            //const shared = userHasConfigRights ? actorVariants.includes(path) : false;
-            //return { route: path, name: getFileName(path), used: path === token.img, img, vid, type: img || vid, shared: shared }
-            let shared = userHasConfigRights ? Array.from(actorVariants.values()).includes(path) : false;
+            const shared = userHasConfigRights ? Array.from(actorVariants.values()).includes(path) : false;
             let newName = (key && key != path) ? key : getFileName(path)
             imagesParsed.push({ route: path, name: newName, used: path === token.img, img, vid, type: img || vid, shared: shared });         
         });
@@ -655,7 +651,7 @@ async function walkFindTokens(path, name = "", bucket = "", filters = null, forg
         } else if (forge) {
             files = await FilePicker.browse("", path, { wildcard: true });
         } else if (rollTableElementName) {
-            // maybe we can do this
+            // maybe we can do better than this
             files = {};
             files.files = [];
             files.dirs = [];
@@ -765,16 +761,12 @@ async function doArtSearch(name, searchType = SEARCH_TYPE.BOTH, ignoreFilterMSRD
 
     for (let search of searches) {
         if (allImages.get(search) !== undefined) continue;
-        
-        //let tokens = map.values();
-        //tokens = Array.from(tokens).filter(token => !usedTokens.has(token))
-        //tokens.forEach(token => usedTokens.add(token));
         let map = await findTokens(search, searchType);
         let tokens = new Map();   
         for (let k of map.keys()) {
             const token = map.get(k);
             if(!usedTokens.has(token)){
-                usedTokens.add(token);                
+                usedTokens.add(token);
                 tokens.set(k, token);
             }
         }

--- a/token-variants.mjs
+++ b/token-variants.mjs
@@ -400,7 +400,7 @@ function registerHUD() {
         }
     }
 
-    // Incorporating 'FVTT-TokenHUDWildcard' token hud button
+    // Incorporating 'FVTT-TokenHUDWildcard' token hud button 
     Hooks.on('renderTokenHUD', renderHud);
 }
 

--- a/token-variants.mjs
+++ b/token-variants.mjs
@@ -21,10 +21,10 @@ let excludedKeywords = [];
 let disableCaching = false;
 
 // A cached map of all the found tokens
-let cachedTokens = new Set();
+let cachedTokens = new Map();
 
 // Tokens found with caching disabled
-let foundTokens = new Set();
+let foundTokens = new Map();
 
 // Tracks if module has been initialized
 let initialized = false;
@@ -287,26 +287,42 @@ function registerHUD() {
 
         const userHasConfigRights = game.user && game.user.can("FILES_BROWSE") && game.user.can("TOKEN_CONFIGURE");
 
-        let images = await doArtSearch(search, SEARCH_TYPE.TOKEN, false, true);
-        images = images.get(search) || [];
+        let mapArtSearch = await doArtSearch(search, SEARCH_TYPE.TOKEN, false, true);
+        let images = mapArtSearch.get(search) || new Map();
 
-        let actorVariants = [];
+        let actorVariants = new Map();
         const tokenActor = game.actors.get(token.actorId);
         if (tokenActor) {
-            actorVariants = tokenActor.getFlag('token-variants', 'variants') || [];
-            actorVariants = actorVariants.filter(path => Boolean(path));
-            if (!searchText)
-                images = [...new Set(images.concat(actorVariants))]
+            actorVariants = tokenActor.getFlag('token-variants', 'variants') || new Map();
+            //actorVariants = actorVariants.filter(path => Boolean(path));
+            if (!searchText){
+                //images = [...new Set(images.concat(actorVariants))]
+                actorVariants.forEach((path, key) => {
+                    if(path){
+                        images.set(key,path)
+                    }
+                });
+            }else{
+                actorVariants.forEach((path, key) => {
+                    if(path){
+                        images.set(key,path)
+                    }
+                });
+            }
         }
 
         const alwaysShowHUD = game.settings.get("token-variants", "alwaysShowHUD");
         if (!alwaysShowHUD && images.length < 2 && actorVariants.length == 0) return;
 
-        let imagesParsed = images.map(path => {
+        let imagesParsed = [];
+        images.forEach((path, key) => {
             const img = isImage(path);
             const vid = isVideo(path);
-            const shared = userHasConfigRights ? actorVariants.includes(path) : false;
-            return { route: path, name: getFileName(path), used: path === token.img, img, vid, type: img || vid, shared: shared }
+            //const shared = userHasConfigRights ? actorVariants.includes(path) : false;
+            //return { route: path, name: getFileName(path), used: path === token.img, img, vid, type: img || vid, shared: shared }
+            let shared = userHasConfigRights ? Array.from(actorVariants.values()).includes(path) : false;
+            let newName = (key && key != path) ? key : getFileName(path)
+            imagesParsed.push({ route: path, name: newName, used: path === token.img, img, vid, type: img || vid, shared: shared });         
         });
 
         const imageDisplay = game.settings.get("token-variants", "HUDDisplayImage");
@@ -381,13 +397,17 @@ function registerHUD() {
                     const variantSelected = event.target.dataset.name;
                     let tokenActor = game.actors.get(updateTarget.actor.id);
                     if (tokenActor) {
-                        let variants = tokenActor.getFlag('token-variants', 'variants') || [];
-                        if (variants.includes(variantSelected)) {
-                            variants.splice(variants.indexOf(variantSelected), 1);
-                        } else {
-                            variants.push(variantSelected);
-                        }
-                        tokenActor.setFlag('token-variants', 'variants', variants);
+                        let variants = tokenActor.getFlag('token-variants', 'variants') || new Map();
+                        //variants.splice(variants.indexOf(variantSelected), 1);
+                        let newVariants = new Map();
+                        variants.forEach((variant, key) => {
+                            if (variant.includes(variantSelected)) {
+                                //
+                            } else {
+                                newVariants.push(key, variant);
+                            }
+                        });
+                        tokenActor.setFlag('token-variants', 'variants', newVariants);
                         event.target.parentNode.querySelector('.fa-share').classList.toggle("active")
                     }
                 });
@@ -523,7 +543,7 @@ async function cacheTokens() {
 
     await findTokens("", "", true);
     cachedTokens = foundTokens;
-    foundTokens = new Set();
+    foundTokens = new Map();
     if (debug) console.log("ENDING: Token Caching");
 }
 
@@ -581,15 +601,23 @@ async function findTokens(name, searchType = "", caching = false) {
     }
     if (filters.regex) filters.regex = new RegExp(filters.regex);
 
-    foundTokens = new Set();
+    foundTokens = new Map();
     const simpleName = simplifyTokenName(name);
 
     if (cachedTokens.size != 0) {
-        cachedTokens.forEach((tokenSrc) => {
+        cachedTokens.forEach((tokenSrc,name)=>{
             const simplified = runSearchOnPath ? simplifyPath(tokenSrc) : simplifyTokenName(getFileName(tokenSrc));
             if (simplified.includes(simpleName)) {
                 if (!filters || checkAgainstFilters(tokenSrc, filters)) {
-                    foundTokens.add(tokenSrc);
+                    if(name){
+                        foundTokens.set(name,tokenSrc);
+                    }else{
+                        foundTokens.set(tokenSrc,tokenSrc);
+                    }
+                }
+            }else if(name && name != tokenSrc){
+                if (!filters || checkAgainstFilters(name, filters)) {
+                    foundTokens.set(name,tokenSrc);
                 }
             }
         });
@@ -626,13 +654,18 @@ async function walkFindTokens(path, name = "", bucket = "", filters = null, forg
             files = await FilePicker.browse("s3", path, { bucket: bucket });
         } else if (forge) {
             files = await FilePicker.browse("", path, { wildcard: true });
-        } else if (rollTable) {
-            files = await FilePicker.browse("", path, { name: rollTableElementName }); // Is the user who made the rollTable
+        } else if (rollTableElementName) {
+            // maybe we can do this
+            files = {};
+            files.files = [];
+            files.dirs = [];
+            files.files.push(path);
+            name = rollTableElementName;
         } else {
             files = await FilePicker.browse("data", path);
         }
     } catch (err) {
-        console.log(`${game.i18n.localize("token-variant.PathNotFoundError")} ${path}`);
+        console.log(`${game.i18n.localize("token-variants.PathNotFoundError")} ${path}`);
         return;
     }
 
@@ -640,18 +673,20 @@ async function walkFindTokens(path, name = "", bucket = "", filters = null, forg
 
     for (let tokenSrc of files.files) {
         if (!name) {
-            foundTokens.add(tokenSrc);
+            foundTokens.set(tokenSrc,tokenSrc);
         } else {
             const simplified = runSearchOnPath ? simplifyPath(tokenSrc) : simplifyTokenName(getFileName(tokenSrc));
             if (simplified.includes(name)) {
                 if (!filters || checkAgainstFilters(tokenSrc, filters)) {
-                    foundTokens.add(tokenSrc);
+                    foundTokens.set(name,tokenSrc);
                 }
+            }else if(rollTableElementName){
+                foundTokens.set(name,tokenSrc);
             }
         }
     }
     for (let dir of files.dirs) {
-        await walkFindTokens(dir, name, bucket, filters, forge, rollTable);
+        await walkFindTokens(dir, name, bucket, filters, forge, "");
     }
 }
 
@@ -683,7 +718,7 @@ async function displayArtSelect(name, callback, searchType = SEARCH_TYPE.BOTH, i
     let allButtons = new Map();
     allImages.forEach((tokens, search) => {
         let buttons = [];
-        tokens.forEach(token => {
+        tokens.forEach((token,name) => {
             artFound = true;
             const vid = isVideo(token);
             const img = isImage(token);
@@ -692,7 +727,7 @@ async function displayArtSelect(name, callback, searchType = SEARCH_TYPE.BOTH, i
                 img: img,
                 vid: vid,
                 type: vid || img,
-                label: getFileName(token),
+                label: (name && name != token) ? name : getFileName(token),
             })
         })
         allButtons.set(search, buttons);
@@ -730,9 +765,19 @@ async function doArtSearch(name, searchType = SEARCH_TYPE.BOTH, ignoreFilterMSRD
 
     for (let search of searches) {
         if (allImages.get(search) !== undefined) continue;
-        let tokens = await findTokens(search, searchType);
-        tokens = Array.from(tokens).filter(token => !usedTokens.has(token))
-        tokens.forEach(token => usedTokens.add(token));
+        
+        //let tokens = map.values();
+        //tokens = Array.from(tokens).filter(token => !usedTokens.has(token))
+        //tokens.forEach(token => usedTokens.add(token));
+        let map = await findTokens(search, searchType);
+        let tokens = new Map();   
+        for (let k of map.keys()) {
+            const token = map.get(k);
+            if(!usedTokens.has(token)){
+                usedTokens.add(token);                
+                tokens.set(k, token);
+            }
+        }
         allImages.set(search, tokens);
     }
 


### PR DESCRIPTION
Related to this request https://github.com/Aedif/TokenVariants/issues/23 (which after seeing the code I realized it was too complex solution for how the code is set up).

I've integrated a solution that I think is acceptable for my use case and how your module works.

In practice I made sure that among the paths to be analyzed the syntax 

`rolltable:<TABLE ID>`

 is accepted to retrieve images from a rolltable (which can be filled in various ways CSV, Compendium, other modules, etc.) and where I can finally use whatever web reference or local file I want.

Another advantage of the solution offered by the rolltable is to associate a specific name to the image without depending on its file name, this makes it possible to associate the "xxx.png" image with the name "Lizardfolk" searchable through your functions.