### PR TITLE
Adding support for rolltables as image sources

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -42,5 +42,6 @@
     "token-variants.portraitArtFilterHint": "Portrait art will be limited to files that include/exclude these pieces of text or match the provided regular expression.",
     "token-variants.generalArtFilterHint": "These filters will be used when the search is being performed irrespective of the art type (token/portrait).",
     "token-variants.ProfileListenerError": "Token-Variant-Art: Unable to find profile image to assign right-click listener.",
-    "token-variant.PathNotFoundError": "Unable to find path: "
+    "token-variants.PathNotFoundError": "Unable to find path: ",
+    "token-variants.notifications.warn.invalidTable": "The table \"{tableId}\" could not be found"
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -39,7 +39,7 @@ export async function parseSearchPaths(debug = false) {
     let searchPaths = new Map();
     searchPaths.set("data", []);
     searchPaths.set("s3", new Map());
-    searchPaths.set("rolltable", new Map());
+    searchPaths.set("rolltable", []);
     let allForgePaths = [];
     async function walkForgePaths(path, currDir) {
         let files;
@@ -76,27 +76,7 @@ export async function parseSearchPaths(debug = false) {
             const match = path.match(regexpRollTable);
             if (match[0]) {
                 let tableId = match[0].split(":")[1];
-                let tables = searchPaths.get("rolltable");
-                const table = game.tables.contents.find((t) => t.name === tableId);
-                if (!table){
-                  ui.notifications.warn(game.i18n.format("token-variants.notifications.warn.invalidTable", { tableId }));
-                } else {
-                  // TODO ADD A RANDOMIZER ?
-                  //const roll = await table.draw({
-                  //	displayChat: "Here the roll text"
-                  //});
-                  // const result = roll.results[0];
-                  const dataTable = table.data;
-                  for (let baseTableData of dataTable.results) {
-                    const path = baseTableData.data.img;
-                    const name = baseTableData.data.text;
-                    if (tables.has(name)) {
-                      // DO NOTHING CAN'T BE HAPPENING
-                    } else {
-                      tables.set(name, path);
-                    }
-                  }
-                }
+                searchPaths.get("rolltable").push(tableId);
             }
         } else {
             const match = path.match(regexpForge);

--- a/templates/sideSelect.html
+++ b/templates/sideSelect.html
@@ -9,14 +9,14 @@
             {{#if ../imageDisplay}}
             {{#if image.img}}
             <img class="token-variants-button-image" src="{{image.route}}" alt="{{image.name}}"
-                data-name="{{image.route}}" style="opacity:{{../imageOpacity}};" />
+                data-name="{{image.route}}" data-filename="{{image.name}}" style="opacity:{{../imageOpacity}};" />
             {{/if}}
             {{#if image.vid}}
             <video class="token-variants-button-image" src="{{image.route}}" alt="{{image.name}}"
-                data-name="{{image.route}}" style="opacity:{{../imageOpacity}};" autoplay loop></video>
+                data-name="{{image.route}}" data-filename="{{image.name}}" style="opacity:{{../imageOpacity}};" autoplay loop></video>
             {{/if}}
             {{else}}
-            <span data-name="{{image.route}}">{{image.name}}</span>
+            <span data-name="{{image.route}}" data-filename="{{image.name}}">{{image.name}}</span>
             {{/if}}
             <i class="fas fa-share {{#if image.shared}}active{{/if}}"></i>
         </button>


### PR DESCRIPTION
* Rolltables can now be added as image sources via 'searchPaths' setting by using the following format:
    * rolltable:{rolltable name} (e.g. rolltable:GoblinVariants)
* Because of rolltables the same image path may now be assigned multiple names. Each of these names will appear as seperate images that can be selected in the ArtSelect pop-up and the TokenHUD side menu.