### PR TITLE
Tile Support

### DIFF
--- a/applications/configureSettings.js
+++ b/applications/configureSettings.js
@@ -309,13 +309,42 @@ export default class ConfigureSettings extends FormApplication {
   `;
     table.append(row);
 
+    this._reIndexPaths(table);
+
     this.setPosition(); // Auto-resize window
+  }
+
+  async _reIndexPaths(table) {
+    table
+      .find('.path-text')
+      .find('input')
+      .each(function (index) {
+        $(this).attr('name', `searchPaths.${index}.text`);
+      });
+
+    table
+      .find('.path-cache')
+      .find('input')
+      .each(function (index) {
+        $(this).attr('name', `searchPaths.${index}.cache`);
+      });
+
+    table
+      .find('.path-tiles')
+      .find('input')
+      .each(function (index) {
+        $(this).attr('name', `searchPaths.${index}.tiles`);
+      });
   }
 
   async _onDeletePath(event) {
     event.preventDefault();
+
     const li = event.currentTarget.closest('.table-row');
     li.remove();
+
+    const table = $(event.currentTarget).closest('.token-variant-table');
+    this._reIndexPaths(table);
 
     this.setPosition(); // Auto-resize window
   }
@@ -357,23 +386,9 @@ export default class ConfigureSettings extends FormApplication {
     formData = expandObject(formData);
 
     // Search Paths
-    const searchPaths = [];
-    if (formData.searchPaths) {
-      if (!Array.isArray(formData.searchPaths.cache)) {
-        formData.searchPaths.cache = [formData.searchPaths.cache];
-        formData.searchPaths.text = [formData.searchPaths.text];
-        if (this.settings.tilesEnabled) formData.searchPaths.tiles = [formData.searchPaths.tiles];
-      }
-
-      for (let i = 0; i < formData.searchPaths.text.length; i++) {
-        if (formData.searchPaths.text[i] !== '') {
-          const sp = { text: formData.searchPaths.text[i], cache: formData.searchPaths.cache[i] };
-          if (this.settings.tilesEnabled) sp.tiles = formData.searchPaths.tiles[i];
-          searchPaths.push(sp);
-        }
-      }
-    }
-    settings.searchPaths = searchPaths;
+    settings.searchPaths = formData.hasOwnProperty('searchPaths')
+      ? Object.values(formData.searchPaths)
+      : [];
 
     // Search Filters
     if (!this._validRegex(formData.searchFilters.portraitFilterRegex)) {

--- a/applications/configureSettings.js
+++ b/applications/configureSettings.js
@@ -33,6 +33,7 @@ export default class ConfigureSettings extends FormApplication {
       r.text = path.text;
       r.icon = this._pathIcon(path.text);
       r.cache = path.cache;
+      r.tiles = path.tiles;
       return r;
     });
     data.searchPaths = paths;
@@ -105,6 +106,7 @@ export default class ConfigureSettings extends FormApplication {
     data.enableStatusConfig = settings.enableStatusConfig;
     data.disableNotifs = settings.disableNotifs;
     data.staticCache = settings.staticCache;
+    data.tilesEnabled = settings.tilesEnabled;
 
     return data;
   }
@@ -276,7 +278,7 @@ export default class ConfigureSettings extends FormApplication {
   async _onCreatePath(event) {
     event.preventDefault();
     const table = $(event.currentTarget).closest('.token-variant-table');
-    const row = `
+    let row = `
     <li class="table-row flexrow">
         <div class="path-image">
             <i class="${this._pathIcon('')}"></i>
@@ -289,7 +291,17 @@ export default class ConfigureSettings extends FormApplication {
         </div>
         <div class="path-cache">
             <input type="checkbox" name="searchPaths.cache" data-dtype="Boolean" checked/>
+        </div>`;
+
+    if (this.settings.tilesEnabled) {
+      row += `
+        <div class="path-tiles">
+          <input type="checkbox" name="searchPaths.tiles" data-dtype="Boolean"/>
         </div>
+      `;
+    }
+
+    row += `
         <div class="path-controls">
             <a class="delete-path" title="Delete path"><i class="fas fa-trash"></i></a>
         </div>
@@ -350,14 +362,14 @@ export default class ConfigureSettings extends FormApplication {
       if (!Array.isArray(formData.searchPaths.cache)) {
         formData.searchPaths.cache = [formData.searchPaths.cache];
         formData.searchPaths.text = [formData.searchPaths.text];
+        if (this.settings.tilesEnabled) formData.searchPaths.tiles = [formData.searchPaths.tiles];
       }
 
       for (let i = 0; i < formData.searchPaths.text.length; i++) {
         if (formData.searchPaths.text[i] !== '') {
-          searchPaths.push({
-            text: formData.searchPaths.text[i],
-            cache: formData.searchPaths.cache[i],
-          });
+          const sp = { text: formData.searchPaths.text[i], cache: formData.searchPaths.cache[i] };
+          if (this.settings.tilesEnabled) sp.tiles = formData.searchPaths.tiles[i];
+          searchPaths.push(sp);
         }
       }
     }
@@ -404,6 +416,7 @@ export default class ConfigureSettings extends FormApplication {
       enableStatusConfig: formData.enableStatusConfig,
       disableNotifs: formData.disableNotifs,
       staticCache: formData.staticCache,
+      tilesEnabled: formData.tilesEnabled,
     });
 
     // Save settings

--- a/applications/searchPaths.js
+++ b/applications/searchPaths.js
@@ -29,12 +29,14 @@ export class ForgeSearchPaths extends FormApplication {
       r.text = path.text;
       r.cache = path.cache;
       r.share = path.share;
+      r.tiles = path.tiles;
       return r;
     });
 
     const data = super.getData(options);
     data.paths = paths;
     data.apiKey = this.apiKey;
+    data.tilesEnabled = TVA_CONFIG.tilesEnabled && game.user.isGM;
     return data;
   }
 
@@ -60,7 +62,7 @@ export class ForgeSearchPaths extends FormApplication {
     event.preventDefault();
     await this._onSubmit(event);
 
-    this.object.paths.push({ text: '', cache: true, share: true });
+    this.object.paths.push({ text: '', cache: true, share: true, tiles: false });
     this.render();
   }
 
@@ -93,6 +95,7 @@ export class ForgeSearchPaths extends FormApplication {
         text: path.text,
         cache: path.cache,
         share: path.share,
+        tiles: path.tiles,
       };
     });
     this.apiKey = expanded.apiKey;

--- a/applications/tileHUD.js
+++ b/applications/tileHUD.js
@@ -1,0 +1,434 @@
+import {
+  getFileName,
+  isImage,
+  isVideo,
+  SEARCH_TYPE,
+  keyPressed,
+  updateActorImage,
+  updateTokenImage,
+} from '../scripts/utils.js';
+// import TokenCustomConfig from './tokenCustomConfig.js';
+import { doImageSearch, findTokensFuzzy } from '../token-variants.mjs';
+import { TVA_CONFIG } from '../scripts/settings.js';
+// import UserList from './userList.js';
+
+// not call if still caching
+export async function renderTileHUD(hud, html, tile, searchText = '') {
+  const hudSettings = TVA_CONFIG.hud;
+  const worldHudSettings = TVA_CONFIG.worldHud;
+
+  console.log('Inside thehook');
+
+  if (!hudSettings.enableSideMenu) return;
+
+  const search = searchText ? searchText : tile._id; // TODO set and read a name flag
+  if (!search || search.length < 3) return;
+
+  const noSearch = !searchText && worldHudSettings.displayOnlySharedImages;
+
+  let artSearch = noSearch
+    ? null
+    : await doImageSearch(search, {
+        searchType: SEARCH_TYPE.TILE,
+        ignoreKeywords: !worldHudSettings.includeKeywords,
+      });
+
+  // Merge full search, and keywords into a single array
+  let images = [];
+  if (artSearch) {
+    artSearch.forEach((results) => {
+      images.push(...results);
+    });
+  }
+
+  let actorVariants = [];
+
+  let tokenActor = false; // TODO
+  if (tokenActor) {
+    actorVariants = tokenActor.getFlag('token-variants', 'variants') || [];
+
+    // To maintain compatibility with previous versions
+    if (!(actorVariants instanceof Array)) {
+      actorVariants = [];
+    } else if (actorVariants.length != 0 && !(actorVariants[0] instanceof Object)) {
+      actorVariants.forEach((src, i) => {
+        actorVariants[i] = { imgSrc: src, names: [getFileName(src)] };
+      });
+    }
+    // end of compatibility code
+
+    if (!searchText) {
+      const mergeImages = function (imgArr) {
+        imgArr.forEach((variant) => {
+          for (const name of variant.names) {
+            if (!images.find((obj) => obj.path === variant.imgSrc && obj.name === name)) {
+              images.unshift({ path: variant.imgSrc, name: name });
+            }
+          }
+        });
+      };
+
+      // Merge images found through search, with variants shared through 'variant' flag
+      mergeImages(actorVariants);
+
+      // Merge wildcard images
+      if (worldHudSettings.includeWildcard && !worldHudSettings.displayOnlySharedImages) {
+        const protoImg = tokenActor.data.token.img;
+        if (protoImg.includes('*') || protoImg.includes('{') || protoImg.includes('}')) {
+          // Modified version of Actor.getTokenImages()
+          const getTokenImages = async () => {
+            if (tokenActor._tokenImages) return tokenActor._tokenImages;
+
+            let source = 'data';
+            let pattern = tokenActor.data.token.img;
+            const browseOptions = { wildcard: true };
+
+            // Support non-user sources
+            if (/\.s3\./.test(pattern)) {
+              source = 's3';
+              const { bucket, keyPrefix } = FilePicker.parseS3URL(pattern);
+              if (bucket) {
+                browseOptions.bucket = bucket;
+                pattern = keyPrefix;
+              }
+            } else if (pattern.startsWith('icons/')) source = 'public';
+
+            // Retrieve wildcard content
+            try {
+              const content = await FilePicker.browse(source, pattern, browseOptions);
+              tokenActor._tokenImages = content.files;
+            } catch (err) {
+              tokenActor._tokenImages = [];
+            }
+            return tokenActor._tokenImages;
+          };
+
+          const wildcardImages = (await getTokenImages())
+            .filter((img) => !img.includes('*'))
+            .map((variant) => {
+              return { imgSrc: variant, names: [getFileName(variant)] };
+            });
+          mergeImages(wildcardImages);
+        }
+      }
+    }
+  }
+
+  // If no images have been found check if the HUD button should be displayed regardless
+  if (!images.length && !actorVariants.length) {
+    if (!hudSettings.alwaysShowButton) return;
+  }
+
+  // Retrieving the possibly custom name attached as a flag to the token
+  let tileImageName = '';
+  if (tile.flags['token-variants'] && tile.flags['token-variants']['name']) {
+    tileImageName = token.flags['token-variants']['name'];
+  } else {
+    tileImageName = getFileName(tile.img);
+  }
+
+  let imagesParsed = [];
+
+  for (const imageObj of images) {
+    const img = isImage(imageObj.path);
+    const vid = isVideo(imageObj.path);
+
+    let shared = false;
+    if (game.user.isGM) {
+      actorVariants.forEach((variant) => {
+        if (variant.imgSrc === imageObj.path && variant.names.includes(imageObj.name)) {
+          shared = true;
+        }
+      });
+    }
+
+    const [title, style] = genTitleAndStyle({}, imageObj.path, imageObj.name);
+
+    imagesParsed.push({
+      route: imageObj.path,
+      name: imageObj.name,
+      used: imageObj.path === tile.img && imageObj.name === tileImageName,
+      img,
+      vid,
+      unknownType: !img && !vid,
+      shared: shared,
+      hasConfig: false, //hasConfig,
+      title: title,
+      style: game.user.isGM && style ? 'box-shadow: ' + style + ';' : null,
+    });
+  }
+
+  //
+  // Render
+  //
+  const imageDisplay = hudSettings.displayAsImage;
+  const imageOpacity = hudSettings.imageOpacity / 100;
+
+  const sideSelect = await renderTemplate('modules/token-variants/templates/sideSelect.html', {
+    imagesParsed,
+    imageDisplay,
+    imageOpacity,
+  });
+
+  let divR = html.find('div.right').append(sideSelect);
+
+  // Activate listeners
+  divR.find('#token-variants-side-button').click(_onSideButtonClick);
+  divR.click(_deactiveTokenVariantsSideSelector);
+  divR.find('.token-variants-button-select').click((event) => _onImageClick(event, tile._id));
+  // Prevent enter key re-loading the world
+  divR.find('.token-variants-side-search').keydown(function (event) {
+    if (event.keyCode == 13) {
+      event.preventDefault();
+      return false;
+    }
+  });
+  divR
+    .find('.token-variants-side-search')
+    .on('keyup', (event) => _onImageSearchKeyUp(event, hud, html, tile));
+
+  //   if (FULL_ACCESS) {
+  divR.find('#token-variants-side-button').on('contextmenu', _onSideButtonRightClick);
+  //     divR
+  //       .find('.token-variants-button-select')
+  //       .on('contextmenu', (event) => _onImageRightClick(event, token._id));
+  //   }
+
+  // If renderHud is being called from text box search the side menu should be enabled by default
+  if (searchText) {
+    divR.find('#token-variants-side-button').parent().addClass('active');
+    divR.find('.token-variants-wrap').addClass('active');
+  }
+}
+
+function _onSideButtonClick(event) {
+  // De-activate 'Status Effects'
+  const is080 = !isNewerVersion('0.8.0', game.version ?? game.data.version);
+  const variantsControlIcon = $(event.target.parentElement);
+  variantsControlIcon
+    .closest('div.right')
+    .find(is080 ? '.control-icon[data-action="effects"]' : 'div.control-icon.effects')
+    .removeClass('active');
+  variantsControlIcon.closest('div.right').find('.status-effects').removeClass('active');
+
+  // Toggle variants side menu
+  variantsControlIcon.toggleClass('active');
+  const variantsWrap = variantsControlIcon.find('.token-variants-wrap');
+  if (variantsControlIcon.hasClass('active')) {
+    variantsWrap.addClass('active');
+  } else {
+    variantsWrap.removeClass('active');
+  }
+}
+
+function _onSideButtonRightClick(event) {
+  // Display side menu if button is not active yet
+  const variantsControlIcon = $(event.target.parentElement);
+  if (!variantsControlIcon.hasClass('active')) {
+    variantsControlIcon.find('#token-variants-side-button').trigger('click');
+  }
+
+  // Display/hide buttons and search input
+  const sideSearch = $(event.target)
+    .closest('div.control-icon')
+    .find('.token-variants-side-search');
+  const buttons = $(event.target).closest('div.control-icon').find('.token-variants-button-select');
+  if (sideSearch.hasClass('active')) {
+    sideSearch.removeClass('active');
+    buttons.removeClass('hide');
+  } else {
+    sideSearch.addClass('active');
+    buttons.addClass('hide');
+  }
+}
+
+function _deactiveTokenVariantsSideSelector(event) {
+  const controlIcon = $(event.target).closest('.control-icon');
+  const dataAction = controlIcon.attr('data-action');
+
+  switch (dataAction) {
+    case 'effects':
+      break; // Effects button
+    case 'thwildcard-selector':
+      break; // Token HUD Wildcard module button
+    default:
+      const is080 = !isNewerVersion('0.8.0', game.version ?? game.data.version);
+      if (is080 && controlIcon.hasClass('effects')) break;
+      return;
+  }
+
+  $(event.target)
+    .closest('div.right')
+    .find('.control-icon[data-action="token-variants-side-selector"]')
+    .removeClass('active');
+  $(event.target).closest('div.right').find('.token-variants-wrap').removeClass('active');
+}
+
+async function _onImageClick(event, tokenId) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  let token = canvas.tokens.controlled.find((t) => t.data._id === tokenId);
+  if (!token) return;
+
+  const worldHudSettings = TVA_CONFIG.worldHud;
+
+  const imgButton = $(event.target).closest('.token-variants-button-select');
+  const imgSrc = imgButton.attr('data-name');
+  const name = imgButton.attr('data-filename');
+
+  if (!imgSrc || !name) return;
+
+  if (keyPressed('config') && game.user.isGM) {
+    const toggleCog = (saved) => {
+      const cog = imgButton.find('.fa-cog');
+      if (saved) {
+        cog.addClass('active');
+      } else {
+        cog.removeClass('active');
+      }
+    };
+    new TokenCustomConfig(token, {}, imgSrc, name, toggleCog).render(true);
+  } else if (token.data.img === imgSrc) {
+    let tileImageName = token.document.getFlag('token-variants', 'name');
+    if (!tileImageName) tileImageName = getFileName(token.data.img);
+    if (tileImageName !== name) {
+      await updateTokenImage(imgSrc, { token: token, imgName: name });
+      if (token.actor && worldHudSettings.updateActorImage) {
+        if (worldHudSettings.useNameSimilarity) {
+          updateActorWithSimilarName(imgSrc, name, token.actor);
+        } else {
+          updateActorImage(token.actor, imgSrc, { imgName: name });
+        }
+      }
+    }
+  } else {
+    await updateTokenImage(imgSrc, { token: token, imgName: name });
+    if (token.actor && worldHudSettings.updateActorImage) {
+      if (worldHudSettings.useNameSimilarity) {
+        updateActorWithSimilarName(imgSrc, name, token.actor);
+      } else {
+        updateActorImage(token.actor, imgSrc, { imgName: name });
+      }
+    }
+  }
+}
+
+function _onImageRightClick(event, tokenId) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  let token = canvas.tokens.controlled.find((t) => t.data._id === tokenId);
+  if (!token) return;
+
+  const imgButton = $(event.target).closest('.token-variants-button-select');
+  const imgSrc = imgButton.attr('data-name');
+  const name = imgButton.attr('data-filename');
+
+  if (!imgSrc || !name) return;
+
+  if (keyPressed('config') && game.user.isGM) {
+    const regenStyle = (token, img) => {
+      const mappings = token.document.getFlag('token-variants', 'userMappings') || {};
+      const name = imgButton.attr('data-filename');
+      const [title, style] = genTitleAndStyle(mappings, img, name);
+
+      imgButton
+        .closest('.token-variants-wrap')
+        .find(`button[data-name='${img}']`)
+        .css('box-shadow', style)
+        .prop('title', title);
+    };
+    new UserList(token, imgSrc, regenStyle).render(true);
+  } else if (token.actor) {
+    let tokenActor = game.actors.get(token.actor.id);
+    let variants = tokenActor.getFlag('token-variants', 'variants') || [];
+
+    // To maintain compatibility with previous versions
+    if (!(variants instanceof Array)) {
+      variants = [];
+    } else if (variants.length != 0 && !(variants[0] instanceof Object)) {
+      variants.forEach((src, i) => {
+        variants[i] = { imgSrc: src, names: [getFileName(src)] };
+      });
+    }
+    // end of compatibility code
+
+    // Remove selected variant if present in the flag, add otherwise
+    let del = false;
+    let updated = false;
+    for (let variant of variants) {
+      if (variant.imgSrc === imgSrc) {
+        let fNames = variant.names.filter((name) => name !== name);
+        if (fNames.length === 0) {
+          del = true;
+        } else if (fNames.length === variant.names.length) {
+          fNames.push(name);
+        }
+        variant.names = fNames;
+        updated = true;
+        break;
+      }
+    }
+    if (del) variants = variants.filter((variant) => variant.imgSrc !== imgSrc);
+    else if (!updated) variants.push({ imgSrc: imgSrc, names: [name] });
+
+    // Set shared variants as an actor flag
+    tokenActor.unsetFlag('token-variants', 'variants');
+    if (variants.length > 0) {
+      tokenActor.setFlag('token-variants', 'variants', variants);
+    }
+    imgButton.find('.fa-share').toggleClass('active'); // Display green arrow
+  }
+}
+
+function _onImageSearchKeyUp(event, hud, html, tileData) {
+  event.preventDefault();
+  event.stopPropagation();
+  if (event.key === 'Enter' || event.keyCode === 13) {
+    if (event.target.value.length >= 3) {
+      $(event.target).closest('.control-icon[data-action="token-variants-side-selector"]').remove();
+      html.find('.control-icon[data-action="token-variants-side-selector"]').remove();
+      renderTileHUD(hud, html, tileData, event.target.value);
+    }
+  }
+  return false;
+}
+
+function genTitleAndStyle(mappings, imgSrc, name) {
+  let title = name;
+  let style = '';
+  let offset = 2;
+  for (const [userId, img] of Object.entries(mappings)) {
+    if (img === imgSrc) {
+      const user = game.users.get(userId);
+      if (!user) continue;
+      if (style.length === 0) {
+        style = `inset 0 0 0 ${offset}px ${user.data.color}`;
+      } else {
+        style += `, inset 0 0 0 ${offset}px ${user.data.color}`;
+      }
+      offset += 2;
+      title += `\nDisplayed to: ${user.data.name}`;
+    }
+  }
+  return [title, style];
+}
+
+async function updateActorWithSimilarName(imgSrc, imgName, actor) {
+  const results = await findTokensFuzzy(
+    imgName,
+    SEARCH_TYPE.PORTRAIT,
+    {
+      fuzzyThreshold: 0.4,
+      fuzzyLimit: 50,
+    },
+    true
+  );
+
+  if (results && results.length !== 0) {
+    updateActorImage(actor, results[0].path, { imgName: results[0].name });
+  } else {
+    updateActorImage(actor, imgSrc, { imgName: imgName });
+  }
+}

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -78,6 +78,7 @@ export const TVA_CONFIG = {
   imgurClientId: '',
   enableStatusConfig: false,
   staticCache: false,
+  tilesEnabled: false,
   compendiumMapper: {
     missingOnly: false,
     diffImages: false,
@@ -181,16 +182,16 @@ export async function registerSettings() {
     onChange: (val) => (TVA_CONFIG.debug = val),
   });
 
-  if (typeof ForgeAPI !== 'undefined') {
-    game.settings.registerMenu('token-variants', 'forgeSearchPaths', {
-      name: game.i18n.localize('token-variants.settings.forge-search-paths.Name'),
-      hint: game.i18n.localize('token-variants.settings.forge-search-paths.Hint'),
-      icon: 'fas fa-search',
-      type: ForgeSearchPaths,
-      scope: 'client',
-      restricted: false,
-    });
-  }
+  // if (typeof ForgeAPI !== 'undefined') {
+  game.settings.registerMenu('token-variants', 'forgeSearchPaths', {
+    name: game.i18n.localize('token-variants.settings.forge-search-paths.Name'),
+    hint: game.i18n.localize('token-variants.settings.forge-search-paths.Hint'),
+    icon: 'fas fa-search',
+    type: ForgeSearchPaths,
+    scope: 'client',
+    restricted: false,
+  });
+  // }
 
   // Deprecated 01/06/2022
   game.settings.register('token-variants', 'searchPaths', {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -8,6 +8,7 @@ export const SEARCH_TYPE = {
   PORTRAIT: 'portrait',
   TOKEN: 'token',
   BOTH: 'both',
+  TILE: 'tile',
 };
 
 export const PRESSED_KEYS = {
@@ -391,10 +392,10 @@ export function getFileNameWithExt(path) {
 }
 
 /**
- * Simplifies token and monster names.
+ * Simplify name.
  */
-export function simplifyTokenName(tokenName) {
-  return tokenName.replace(simplifyRegex, '').toLowerCase();
+export function simplifyName(name) {
+  return name.replace(simplifyRegex, '').toLowerCase();
 }
 
 export function simplifyPath(path) {
@@ -456,17 +457,21 @@ export async function parseSearchPaths(config) {
         let buckets = searchPaths.get('s3');
 
         if (buckets.has(bucket)) {
-          buckets.get(bucket).push({ text: bPath, cache: path.cache });
+          buckets.get(bucket).push({ text: bPath, cache: path.cache, tiles: path.tiles });
         } else {
-          buckets.set(bucket, [{ text: bPath, cache: path.cache }]);
+          buckets.set(bucket, [{ text: bPath, cache: path.cache, tiles: path.tiles }]);
         }
       }
     } else if (path.text.startsWith('rolltable:')) {
-      searchPaths.get('rolltable').push({ text: path.text.split(':')[1], cache: path.cache });
+      searchPaths
+        .get('rolltable')
+        .push({ text: path.text.split(':')[1], cache: path.cache, tiles: path.tiles });
     } else if (path.text.startsWith('imgur:')) {
-      searchPaths.get('imgur').push({ text: path.text.split(':')[1], cache: path.cache });
+      searchPaths
+        .get('imgur')
+        .push({ text: path.text.split(':')[1], cache: path.cache, tiles: path.tiles });
     } else {
-      searchPaths.get('data').push({ text: path.text, cache: path.cache });
+      searchPaths.get('data').push({ text: path.text, cache: path.cache, tiles: path.tiles });
     }
   }
 
@@ -483,7 +488,7 @@ export async function parseSearchPaths(config) {
 export function parseKeywords(keywords) {
   return keywords
     .split(/\W/)
-    .map((word) => simplifyTokenName(word))
+    .map((word) => simplifyName(word))
     .filter((word) => word != '');
 }
 

--- a/styles/tva-styles.css
+++ b/styles/tva-styles.css
@@ -296,7 +296,8 @@ ol.token-variant-table .table-row .path-image img {
 ol.token-variant-table .table-row .path-text {
   flex: 1;
 }
-ol.token-variant-table .table-row .path-cache {
+ol.token-variant-table .table-row .path-cache,
+ol.token-variant-table .table-row .path-tiles {
   flex: 0 0 50px;
   text-align: center;
 }
@@ -344,6 +345,7 @@ ol.token-variant-table .table-row .effect-image {
 /* ---------------------------------------- */
 /* Token HUD Settings                       */
 /* ---------------------------------------- */
+#tile-hud .token-variants-wrap,
 #token-hud .token-variants-wrap {
   position: absolute;
   left: 75px;
@@ -357,14 +359,18 @@ ol.token-variant-table .table-row .effect-image {
   grid-template-columns: 100px 100px 100px;
   overflow-y: auto;
 }
+#tile-hud .token-variants-wrap.list,
 #token-hud .token-variants-wrap.list {
   grid-template-columns: unset !important;
   max-width: 450px;
 }
 
+#tile-hud .token-variants-wrap.active,
 #token-hud .token-variants-wrap.active {
   visibility: visible;
 }
+
+#tile-hud .token-variants-button-select,
 #token-hud .token-variants-button-select {
   max-width: 300px;
   overflow-wrap: break-word;
@@ -377,10 +383,12 @@ ol.token-variant-table .table-row .effect-image {
   position: relative;
 }
 
+#tile-hud .token-variants-button-select.hide,
 #token-hud .token-variants-button-select.hide {
   display: none;
 }
 
+#tile-hud .token-variants-button-select .fa-share,
 #token-hud .token-variants-button-select .fa-share {
   position: absolute;
   left: 0;
@@ -389,6 +397,7 @@ ol.token-variant-table .table-row .effect-image {
   pointer-events: none;
 }
 
+#tile-hud .token-variants-button-select .fa-cog,
 #token-hud .token-variants-button-select .fa-cog {
   position: absolute;
   right: 0;
@@ -397,26 +406,32 @@ ol.token-variant-table .table-row .effect-image {
   pointer-events: none;
 }
 
+#tile-hud .token-variants-button-select .fa-cog.active,
 #token-hud .token-variants-button-select .fa-cog.active {
   opacity: 1;
 }
 
+#tile-hud .token-variants-button-select .fa-share.active,
 #token-hud .token-variants-button-select .fa-share.active {
   opacity: 1;
 }
 
+#tile-hud .token-variants-side-search,
 #token-hud .token-variants-side-search {
   display: none;
 }
 
+#tile-hud .token-variants-side-search.active,
 #token-hud .token-variants-side-search.active {
   display: block;
 }
 
+#tile-hud .token-variants-button-select:hover .token-variants-button-image,
 #token-hud .token-variants-button-select:hover .token-variants-button-image {
   opacity: 1 !important;
 }
 
+#tile-hud .token-variants-button-select.list,
 #token-hud .token-variants-button-select.list {
   max-width: 440px;
   width: 100% !important;
@@ -424,6 +439,7 @@ ol.token-variant-table .table-row .effect-image {
   line-height: 40px !important;
 }
 
+#tile-hud .token-variants-button-image,
 #token-hud .token-variants-button-image {
   width: 100px;
   height: 100px;
@@ -437,15 +453,32 @@ ol.token-variant-table .table-row .effect-image {
   opacity: 1 !important;
   filter: grayscale(100%);
 }
+
+#tile-hud .token-variants-button-disabled span,
+#tile-hud .token-variants-button-disabled img,
+#tile-hud .token-variants-button-disabled video {
+  opacity: 1 !important;
+  filter: grayscale(100%);
+}
+
 #token-hud .token-variants-button-disabled span,
 #token-hud .token-variants-button-disabled:hover img,
 #token-hud .token-variants-button-disabled:hover video {
   color: #ccc;
 }
 
+#tile-hud .token-variants-button-disabled span,
+#tile-hud .token-variants-button-disabled:hover img,
+#tile-hud .token-variants-button-disabled:hover video {
+  color: #ccc;
+}
+
+.tile-sheet .token-variants-default,
 .token-sheet .token-variants-default {
   display: none;
 }
+
+.tile-sheet .token-variants-default.active,
 .token-sheet .token-variants-default.active {
   display: block;
 }

--- a/templates/configureSettings.html
+++ b/templates/configureSettings.html
@@ -35,7 +35,7 @@
                     <i class="{{path.icon}}"></i>
                   </div>
                   <div class="path-text">
-                    <input class="searchPath" type="text" name="searchPaths.text" value="{{path.text}}" placeholder="Path to image source"
+                    <input class="searchPath" type="text" name="searchPaths.{{index}}.text" value="{{path.text}}" placeholder="Path to image source"
                     />
                   </div>
                   <div class="imgur-control {{#if (eq path.type 'imgur')}}active{{/if}}">
@@ -44,11 +44,11 @@
                     </a>
                   </div>
                   <div class="path-cache">
-                    <input type="checkbox" name="searchPaths.cache" data-dtype="Boolean" {{#if path.cache}}checked{{/if}}/>
+                    <input type="checkbox" name="searchPaths.{{index}}.cache" data-dtype="Boolean" {{#if path.cache}}checked{{/if}}/>
                   </div>
                   {{#if ../tilesEnabled}}
                   <div class="path-tiles">
-                    <input type="checkbox" name="searchPaths.tiles" data-dtype="Boolean" {{#if path.tiles}}checked{{/if}}/>
+                    <input type="checkbox" name="searchPaths.{{index}}.tiles" data-dtype="Boolean" {{#if path.tiles}}checked{{/if}}/>
                   </div>
                   {{/if}}
                   <div class="path-controls">
@@ -536,7 +536,7 @@
           <hr>
 
           <div class="form-group">
-            <label>Tile Support</label>
+            <label>Tile HUD</label>
             <div class="form-fields">
               <input type="checkbox" name="tilesEnabled" data-dtype="Boolean" {{#if tilesEnabled}}checked{{/if}}>
             </div>

--- a/templates/configureSettings.html
+++ b/templates/configureSettings.html
@@ -23,6 +23,9 @@
                   </div>
                   <div class="path-text"><label>Path</label></div>
                   <div class="path-cache"><label>Cache</label></div>
+                  {{#if tilesEnabled}}
+                  <div class="path-tiles"><label>Tiles</label></div>
+                  {{/if}}
                   <div class="path-controls"></div>
                 </li>
           
@@ -43,6 +46,11 @@
                   <div class="path-cache">
                     <input type="checkbox" name="searchPaths.cache" data-dtype="Boolean" {{#if path.cache}}checked{{/if}}/>
                   </div>
+                  {{#if ../tilesEnabled}}
+                  <div class="path-tiles">
+                    <input type="checkbox" name="searchPaths.tiles" data-dtype="Boolean" {{#if path.tiles}}checked{{/if}}/>
+                  </div>
+                  {{/if}}
                   <div class="path-controls">
                     <a class="delete-path" title="Delete path"><i class="fas fa-trash"></i></a>
                   </div>
@@ -526,6 +534,14 @@
             </button>
           </div>
           <hr>
+
+          <div class="form-group">
+            <label>Tile Support</label>
+            <div class="form-fields">
+              <input type="checkbox" name="tilesEnabled" data-dtype="Boolean" {{#if tilesEnabled}}checked{{/if}}>
+            </div>
+            <p class="notes">Enables Tile specific search paths and a Tile HUD button.</p>
+          </div>
 
           <div class="form-group">
             <label>{{localize "token-variants.settings.disable-notifs.Name"}}</label>

--- a/templates/searchPaths.html
+++ b/templates/searchPaths.html
@@ -17,6 +17,9 @@
         <div class="path-text"><label>Path</label></div>
         <div class="path-cache"><label>Cache</label></div>
         <div class="path-share"><label>Share</label></div>
+        {{#if tilesEnabled}}
+        <div class="path-tiles"><label>Tiles</label></div>
+        {{/if}}
         <div class="path-controls"></div>
       </li>
 
@@ -26,21 +29,19 @@
           <i class="fas fa-hammer"></i>
         </div>
         <div class="path-text">
-          <input
-            type="text"
-            name="paths.{{index}}.text"
-            value="{{path.text}}"
-            placeholder="Path to image source"
-          />
+          <input type="text" name="paths.{{index}}.text" value="{{path.text}}" placeholder="Path to image source"/>
         </div>
         <div class="path-cache">
-          <input type="checkbox" name="paths.{{index}}.cache" data-dtype="Boolean" {{#if
-          path.cache}}checked{{/if}}/>
+          <input type="checkbox" name="paths.{{index}}.cache" data-dtype="Boolean" {{#if path.cache}}checked{{/if}}/>
         </div>
         <div class="path-share">
-          <input type="checkbox" name="paths.{{index}}.share" data-dtype="Boolean" {{#if
-          path.share}}checked{{/if}}/>
+          <input type="checkbox" name="paths.{{index}}.share" data-dtype="Boolean" {{#if path.share}}checked{{/if}}/>
         </div>
+        {{#if ../tilesEnabled}}
+        <div class="path-tiles">
+          <input type="checkbox" name="paths.{{index}}.tiles" data-dtype="Boolean" {{#if path.tiles}}checked{{/if}}/>
+        </div>
+        {{/if}}
         <div class="path-controls">
           <a class="delete-path" title="Delete path"><i class="fas fa-trash"></i></a>
         </div>


### PR DESCRIPTION
New Setting: **Tile HUD**
- Adding new search path options to split images to Portrait/Token and Tiles.
- Tile HUD includes a new button
  - Can perform searches on tile source images
  - 'Share' images thus pinning them to the tile
  - Assign a name to the tile to be used for the image search