### PR TITLE
Fix FoundryVTT Version Check

### DIFF
--- a/token-variants.mjs
+++ b/token-variants.mjs
@@ -529,7 +529,7 @@ async function initialize() {
       'WRAPPER'
     );
 
-    if (isNewerVersion('10', game.version)) {
+    if (isNewerVersion(game.version, '10')) {
       libWrapper.register(
         'token-variants',
         'Token.prototype._refreshIcon',


### PR DESCRIPTION
The `isNewerVersion` function checks whether the first argument is greater than the second argument, not the other way around.