### PR TITLE
Change `name` to `id` in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,5 +1,5 @@
 {
-  "name": "token-variants",
+  "id": "token-variants",
   "title": "Token Variant Art",
   "description": "Searches a customizable list of directories and displays art variants for tokens/actors through pop-ups and a new Token HUD button. Variants can be individually shared with players allowing them to switch out their token art on the fly.",
   "version": "4.33.0",


### PR DESCRIPTION
As of recently(?) the manifest requires the `id` field and not `name`.

This change updates the field name to match the latest guideline.