### PR TITLE
Fix #181: Get updating prototype tokens working again

### DIFF
--- a/token-variants/scripts/utils.js
+++ b/token-variants/scripts/utils.js
@@ -223,14 +223,14 @@ export async function updateTokenImage(
       TokenDataAdapter.formToData(token, tokenUpdateObj);
       if (TVA_CONFIG.updateTokenProto && token.actor) {
         if (update) {
-          foundry.utils.mergeObject(update, { token: tokenUpdateObj });
+          foundry.utils.mergeObject(update, { prototypeToken: tokenUpdateObj });
         } else {
           // Timeout to prevent race conditions with other modules namely MidiQOL
           // this is a low priority update so it should be Ok to do
           if (token.actorLink) {
-            setTimeout(() => queueActorUpdate(token.actor.id, { token: tokenUpdateObj }), 500);
-          } else {
-            setTimeout(() => token.actor.update({ token: tokenUpdateObj }), 500);
+            setTimeout(() => queueActorUpdate(token.actor.id, { prototypeToken: tokenUpdateObj }), 500);
+          } else if (token.baseActor) {
+            setTimeout(() => token.baseActor.update({ prototypeToken: tokenUpdateObj }), 500);
           }
         }
       }


### PR DESCRIPTION
This patch fixes the "Transfer Token Updates to Prototype" option, which broke in Foundry v12. Technical details in the commit message.

I have not tested in Foundry v11, so please do that before merging. I have confirmed from reading the docs that the changes I made here should also be compatible there.

I have also not tested the `if (update)` branch condition of the code because I have no idea what it's doing.
But the other two modified lines (handling actor link enabled or not) are tested and working.