### PR TITLE
Fix #183: Support second-generation dnd5e sheets

### DIFF
--- a/token-variants/scripts/hooks/artSelectButtonHooks.js
+++ b/token-variants/scripts/hooks/artSelectButtonHooks.js
@@ -171,7 +171,7 @@ function _modActorSheet(actorSheet, html, options) {
   if (options.editable && TVA_CONFIG.permissions.portrait_right_click[game.user.role]) {
     let profile = null;
     let profileQueries = {
-      all: ['.profile', '.profile-img', '.profile-image'],
+      all: ['.profile', '.profile-img', '.profile-image', '.portrait'],
       pf2e: ['.player-image', '.actor-icon', '.sheet-header img', '.actor-image'],
     };
 


### PR DESCRIPTION
Hi, another small one for you to help with v12 and dnd5e3.0 compatibility.
Right-clicking does now require clicking the wrench icon to enter edit mode, but I think this is ok because that's consistent with how the character sheets work otherwise.

This adds the `.portrait` selector when setting up the right-click handler. This selector is used by the second-generation character sheets for both PCs and NPCs in newer versions of the dnd5e system.

As an alternative, maybe `.portrait` should be added to a new `dnd5e`-specific check similar to the `pf2e` checks?