### PR TITLE
Respect animation setting when using randomizer

### DIFF
--- a/token-variants/scripts/hooks/popUpRandomizeHooks.js
+++ b/token-variants/scripts/hooks/popUpRandomizeHooks.js
@@ -24,6 +24,7 @@ async function _createToken(token, options, userId) {
     inplace: false,
     recursive: false,
   });
+  const worldHudSettings = TVA_CONFIG.worldHud;
 
   let vDown = keyPressed('v');
   const flagTarget = token.actor ? game.actors.get(token.actor.id) : token.document ?? token;
@@ -56,6 +57,7 @@ async function _createToken(token, options, userId) {
           token: token,
           actor: token.actor,
           imgName: img[1],
+          animate: worldHudSettings.animate,
         });
       }
 


### PR DESCRIPTION
Makes the setting also work when adding the token with randomizer enabled, not just when changing the image manually.

<img width="711" height="71" alt="image" src="https://github.com/user-attachments/assets/a83abf59-9653-4c9e-88a5-52a26941734f" />
