### PR TITLE
Fix portrait right-click on ApplicationV2 actor sheets

### DIFF
--- a/token-variants/scripts/hooks/artSelectButtonHooks.js
+++ b/token-variants/scripts/hooks/artSelectButtonHooks.js
@@ -160,8 +160,10 @@ function _modActorSheet(actorSheet, html, options) {
   // isEditable works on both ApplicationV1 and V2 sheets; the third hook arg is not
   // consistent across the two (v1 passes render data, v2 passes the render context).
   if (actorSheet.isEditable && TVA_CONFIG.permissions.portrait_right_click[game.user.role]) {
-    // renderActorSheet passes a jQuery object, renderActorSheetV2 a raw HTMLElement.
-    const element = html[0] ?? html;
+    // renderActorSheet passes a jQuery object, renderActorSheetV2 a raw element.
+    // Don't use `html[0]`: a V2 sheet's root is a <form>, whose [0] is its first
+    // control, not undefined. Detect jQuery explicitly via its `.jquery` marker.
+    const element = html.jquery ? html[0] : html;
 
     let profile = null;
     let profileQueries = {

--- a/token-variants/scripts/hooks/artSelectButtonHooks.js
+++ b/token-variants/scripts/hooks/artSelectButtonHooks.js
@@ -10,13 +10,14 @@ export function registerArtSelectButtonHooks() {
   // Insert right-click listeners to open up ArtSelect forms from various contexts
   if (TVA_CONFIG.permissions.portrait_right_click[game.user.role]) {
     registerHook(feature_id, 'renderActorSheet', _modActorSheet);
+    registerHook(feature_id, 'renderActorSheetV2', _modActorSheet);
     if (game.system.id === 'dnd5e') registerHook(feature_id, 'renderItemSheet5e', _modItemSheet);
     registerHook(feature_id, 'renderItemActionSheet', _modItemSheet);
     if (game.system.id === 'pf1') registerHook(feature_id, 'renderItemSheetPF', _modItemSheetPF);
     registerHook(feature_id, 'renderJournalSheet', _modJournalSheet);
   } else {
-    ['renderActorSheet', 'renderItemSheet5e', 'renderItemActionSheet', 'renderJournalSheet'].forEach((name) =>
-      unregisterHook(feature_id, name),
+    ['renderActorSheet', 'renderActorSheetV2', 'renderItemSheet5e', 'renderItemActionSheet', 'renderJournalSheet'].forEach(
+      (name) => unregisterHook(feature_id, name),
     );
   }
 
@@ -156,7 +157,12 @@ function _modJournalSheet(journalSheet, html, options) {
  * the 'Art Select' screen.
  */
 function _modActorSheet(actorSheet, html, options) {
-  if (options.editable && TVA_CONFIG.permissions.portrait_right_click[game.user.role]) {
+  // isEditable works on both ApplicationV1 and V2 sheets; the third hook arg is not
+  // consistent across the two (v1 passes render data, v2 passes the render context).
+  if (actorSheet.isEditable && TVA_CONFIG.permissions.portrait_right_click[game.user.role]) {
+    // renderActorSheet passes a jQuery object, renderActorSheetV2 a raw HTMLElement.
+    const element = html[0] ?? html;
+
     let profile = null;
     let profileQueries = {
       all: ['.profile', '.profile-img', '.profile-image', '.portrait'],
@@ -164,13 +170,13 @@ function _modActorSheet(actorSheet, html, options) {
     };
 
     for (let query of profileQueries.all) {
-      profile = html[0].querySelector(query);
+      profile = element.querySelector(query);
       if (profile) break;
     }
 
     if (!profile && game.system.id in profileQueries) {
       for (let query of profileQueries[game.system.id]) {
-        profile = html[0].querySelector(query);
+        profile = element.querySelector(query);
         if (profile) break;
       }
     }
@@ -179,6 +185,11 @@ function _modActorSheet(actorSheet, html, options) {
       console.warn('TVA |', game.i18n.localize('token-variants.notifications.warn.profile-image-not-found'));
       return;
     }
+
+    // Guard against stacking listeners when the hook fires repeatedly for the same
+    // element (e.g. sheets that re-render in place rather than rebuilding the DOM).
+    if (profile.dataset.tvaPortraitListener) return;
+    profile.dataset.tvaPortraitListener = 'true';
 
     profile.addEventListener(
       'contextmenu',


### PR DESCRIPTION
Fixes #226. Likely also resolves #163 and #191 (v2 / Tidy sheets).

Portrait right-click → Art Select silently stopped working on ApplicationV2 actor sheets (Foundry v14 made these the default): `_modActorSheet` is registered on `renderActorSheet` only, but V2 sheets fire `renderActorSheetV2` — so the handler never runs, with no console error (#226). This registers on both hooks and gates on `actorSheet.isEditable` (the third hook arg differs across v1/v2).

Element normalization: a `DocumentSheetV2` root is a `<form>`, and `form[0]` returns the form’s first control, not `undefined` — so `html[0] ?? html` picks the wrong node and the portrait is never found. This detects jQuery via its `.jquery` marker instead: `html.jquery ? html[0] : html`.

Tested live in Foundry v14: portrait right-click opens Art Select on dnd5e 5.0.4 v2 sheets, a third-party v2 sheet, and the legacy v1 sheet (unchanged).

#163 (Default vs Legacy 5e) and #191 (Tidy) share the same v2-hook root cause; the portrait path should be resolved, though #163 also mentions prototype-token config (a separate path) and #191 depends on the Tidy portrait carrying a matched selector.